### PR TITLE
Add morning briefing workflow scaffolding

### DIFF
--- a/configs/alpha_vantage.json
+++ b/configs/alpha_vantage.json
@@ -1,0 +1,5 @@
+{
+  "api_key": "YOUR_ALPHA_VANTAGE_KEY",
+  "symbol": "SPY",
+  "mock_price": 400.0
+}

--- a/configs/economic_calendar.json
+++ b/configs/economic_calendar.json
@@ -1,0 +1,17 @@
+{
+  "provider": "mock-calendar",
+  "metadata": {
+    "events": [
+      {
+        "timestamp": "2023-01-01T07:00:00+00:00",
+        "event": "Manufacturing PMI",
+        "importance": "medium"
+      },
+      {
+        "timestamp": "2023-01-01T09:30:00+00:00",
+        "event": "Unemployment Rate",
+        "importance": "high"
+      }
+    ]
+  }
+}

--- a/configs/twelve_data.json
+++ b/configs/twelve_data.json
@@ -1,0 +1,5 @@
+{
+  "api_key": "YOUR_TWELVE_DATA_KEY",
+  "instruments": ["EUR/USD", "GBP/USD"],
+  "mock_quote": 1.08
+}

--- a/configs/yfinance.json
+++ b/configs/yfinance.json
@@ -1,0 +1,4 @@
+{
+  "ticker": "^GSPC",
+  "mock_price": 4200.5
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,49 @@
+# Assistant Architecture Overview
+
+## Morning Preparation Workflow
+
+The `assistant.morning` package encapsulates the orchestration logic for the
+morning preparation workflow. The central `MorningPreparationService` class
+coordinates the following steps:
+
+1. **Collect Market Context** – gathers placeholder market snapshots from the
+   configured data connectors (Alpha Vantage, Twelve Data, yfinance).
+2. **Fetch Economic Events** – pulls upcoming events from the economic calendar
+   client.
+3. **Build Trading Scenarios** – aggregates scenario insights. Stubbed builders
+   can be replaced with real analytics modules.
+4. **Generate Briefing Report** – assembles a textual report for downstream
+   distribution channels.
+
+`create_default_service` wires the service with stub connectors backed by the
+configuration files found in `configs/`.
+
+## Data Layer
+
+The `assistant.data` package provides lightweight connectors for third-party
+market data providers. Each connector exposes a `fetch_latest_snapshot()` method
+returning structured payloads. Configuration is supplied through JSON files in
+`configs/` and loaded via `assistant.data.config.load_json_config`.
+
+An `EconomicCalendarClient` delivers placeholder event data that can later be
+extended to integrate with a real provider.
+
+## Scheduling
+
+The `assistant.scheduler` package introduces a Celery-based (optional) stub for
+triggering the morning preparation workflow and session hooks. The
+`scheduler_app` object is initialised only when Celery is installed. When
+available, it registers periodic tasks defined in `SESSION_SCHEDULE` that cover:
+
+- 07:30 CET – Morning briefing generation via `MorningPreparationService`.
+- 09:00, 11:00, 14:30, 17:00, 20:00 CET – Session-specific hook placeholders.
+
+Projects that prefer Airflow or another scheduler can replace the Celery stub
+while reusing the schedule metadata exported in `SESSION_SCHEDULE`.
+
+## Command Line Interface
+
+The `scripts/run_morning_briefing.py` entry point constructs the default service
+and prints the generated briefing. The script accepts an optional export path to
+persist the generated report, making it easy to integrate the workflow into
+cron jobs or deployment pipelines.

--- a/scripts/run_morning_briefing.py
+++ b/scripts/run_morning_briefing.py
@@ -1,0 +1,44 @@
+"""CLI entry point for executing the morning briefing workflow."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from assistant.morning import create_default_service
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the morning market briefing workflow.")
+    parser.add_argument(
+        "--export",
+        type=Path,
+        default=None,
+        help="Optional path to export the generated briefing report.",
+    )
+    parser.add_argument(
+        "--config-dir",
+        type=Path,
+        default=Path("configs"),
+        help="Directory containing connector configuration files.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    service = create_default_service(str(args.config_dir))
+    report = service.run()
+    print(report)
+    if args.export is not None:
+        args.export.write_text(report, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Core source package for assistant services."""

--- a/src/assistant/__init__.py
+++ b/src/assistant/__init__.py
@@ -1,0 +1,1 @@
+"""Assistant package providing orchestration services."""

--- a/src/assistant/data/__init__.py
+++ b/src/assistant/data/__init__.py
@@ -1,0 +1,13 @@
+"""Data ingestion utilities for the assistant platform."""
+
+from .connectors.alpha_vantage import AlphaVantageConnector
+from .connectors.twelve_data import TwelveDataConnector
+from .connectors.yfinance import YFinanceConnector
+from .economic_calendar import EconomicCalendarClient
+
+__all__ = [
+    "AlphaVantageConnector",
+    "TwelveDataConnector",
+    "YFinanceConnector",
+    "EconomicCalendarClient",
+]

--- a/src/assistant/data/config.py
+++ b/src/assistant/data/config.py
@@ -1,0 +1,28 @@
+"""Configuration helpers for data connectors."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def load_json_config(path: str | Path) -> Dict[str, Any]:
+    """Load a JSON configuration file.
+
+    Parameters
+    ----------
+    path:
+        The path to the configuration file.
+
+    Returns
+    -------
+    Dict[str, Any]
+        Parsed configuration data. Returns an empty dictionary if the file
+        does not exist.
+    """
+    config_path = Path(path)
+    if not config_path.exists():
+        return {}
+    with config_path.open("r", encoding="utf-8") as config_file:
+        return json.load(config_file)

--- a/src/assistant/data/connectors/__init__.py
+++ b/src/assistant/data/connectors/__init__.py
@@ -1,0 +1,11 @@
+"""Connector stubs for various market data providers."""
+
+from .alpha_vantage import AlphaVantageConnector
+from .twelve_data import TwelveDataConnector
+from .yfinance import YFinanceConnector
+
+__all__ = [
+    "AlphaVantageConnector",
+    "TwelveDataConnector",
+    "YFinanceConnector",
+]

--- a/src/assistant/data/connectors/alpha_vantage.py
+++ b/src/assistant/data/connectors/alpha_vantage.py
@@ -1,0 +1,35 @@
+"""Alpha Vantage market data connector stub."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class AlphaVantageConnector:
+    """Placeholder connector for the Alpha Vantage API."""
+
+    api_key: Optional[str] = None
+    symbol: str = "SPY"
+    session: Any = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    name: str = "alpha_vantage"
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "AlphaVantageConnector":
+        """Instantiate the connector from configuration values."""
+        return cls(
+            api_key=config.get("api_key"),
+            symbol=config.get("symbol", "SPY"),
+            metadata={k: v for k, v in config.items() if k not in {"api_key", "symbol"}},
+        )
+
+    def fetch_latest_snapshot(self) -> Dict[str, Any]:
+        """Retrieve a placeholder market snapshot from Alpha Vantage."""
+        return {
+            "symbol": self.symbol,
+            "price": self.metadata.get("mock_price", 0.0),
+            "source": self.name,
+        }

--- a/src/assistant/data/connectors/twelve_data.py
+++ b/src/assistant/data/connectors/twelve_data.py
@@ -1,0 +1,35 @@
+"""Twelve Data market data connector stub."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class TwelveDataConnector:
+    """Placeholder connector for Twelve Data API."""
+
+    api_key: Optional[str] = None
+    instruments: list[str] = field(default_factory=lambda: ["EUR/USD"])
+    session: Any = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    name: str = "twelve_data"
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "TwelveDataConnector":
+        """Instantiate the connector from configuration values."""
+        return cls(
+            api_key=config.get("api_key"),
+            instruments=config.get("instruments", ["EUR/USD"]),
+            metadata={k: v for k, v in config.items() if k not in {"api_key", "instruments"}},
+        )
+
+    def fetch_latest_snapshot(self) -> Dict[str, Any]:
+        """Return a placeholder snapshot for FX instruments."""
+        return {
+            "instruments": self.instruments,
+            "quote": self.metadata.get("mock_quote", 0.0),
+            "source": self.name,
+        }

--- a/src/assistant/data/connectors/yfinance.py
+++ b/src/assistant/data/connectors/yfinance.py
@@ -1,0 +1,33 @@
+"""yfinance market data connector stub."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class YFinanceConnector:
+    """Placeholder connector for the yfinance library."""
+
+    ticker: str = "^GSPC"
+    session: Any = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    name: str = "yfinance"
+
+    @classmethod
+    def from_config(cls, config: Dict[str, Any]) -> "YFinanceConnector":
+        """Instantiate the connector from configuration values."""
+        return cls(
+            ticker=config.get("ticker", "^GSPC"),
+            metadata={k: v for k, v in config.items() if k not in {"ticker"}},
+        )
+
+    def fetch_latest_snapshot(self) -> Dict[str, Any]:
+        """Return a placeholder quote for an index or equity."""
+        return {
+            "ticker": self.ticker,
+            "price": self.metadata.get("mock_price", 0.0),
+            "source": self.name,
+        }

--- a/src/assistant/data/economic_calendar.py
+++ b/src/assistant/data/economic_calendar.py
@@ -1,0 +1,34 @@
+"""Economic calendar client placeholder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+
+def _current_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class EconomicCalendarClient:
+    """Stub client that simulates fetching upcoming economic events."""
+
+    provider: str = "mock"
+    session: Any = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def fetch_events(self) -> List[Dict[str, Any]]:
+        """Return placeholder economic events."""
+        events = self.metadata.get("events")
+        if events is not None:
+            return events
+        return [
+            {
+                "timestamp": _current_timestamp(),
+                "event": "Central bank speech",
+                "importance": "high",
+                "provider": self.provider,
+            }
+        ]

--- a/src/assistant/morning/__init__.py
+++ b/src/assistant/morning/__init__.py
@@ -1,0 +1,11 @@
+"""Morning preparation workflow components."""
+
+from __future__ import annotations
+
+import pkgutil
+
+__path__ = pkgutil.extend_path(__path__, __name__)
+
+from .service import MorningPreparationService, create_default_service
+
+__all__ = ["MorningPreparationService", "create_default_service"]

--- a/src/assistant/morning/service.py
+++ b/src/assistant/morning/service.py
@@ -1,0 +1,132 @@
+"""Morning briefing orchestration service."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional
+
+from ..data import (
+    AlphaVantageConnector,
+    EconomicCalendarClient,
+    TwelveDataConnector,
+    YFinanceConnector,
+)
+from ..data.config import load_json_config
+
+
+@dataclass
+class MorningPreparationService:
+    """Coordinate the steps required for the morning market briefing."""
+
+    market_connectors: Iterable[Any] = field(default_factory=list)
+    economic_calendar: Optional[Any] = None
+    scenario_builders: Iterable[Any] = field(default_factory=list)
+
+    def collect_market_context(self) -> Dict[str, Any]:
+        """Collect market data snapshots from configured connectors."""
+        context: Dict[str, Any] = {}
+        for connector in self.market_connectors:
+            fetch = getattr(connector, "fetch_latest_snapshot", None)
+            if callable(fetch):
+                context[getattr(connector, "name", connector.__class__.__name__)] = fetch()
+        return context
+
+    def fetch_economic_events(self) -> List[Dict[str, Any]]:
+        """Fetch the latest economic calendar events."""
+        if self.economic_calendar is None:
+            return []
+        fetch = getattr(self.economic_calendar, "fetch_events", None)
+        if callable(fetch):
+            return list(fetch())
+        return []
+
+    def build_trading_scenarios(
+        self,
+        market_context: Dict[str, Any],
+        economic_events: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Build trading scenarios based on collected data."""
+        scenarios: List[Dict[str, Any]] = []
+        for builder in self.scenario_builders:
+            build = getattr(builder, "build", None)
+            if callable(build):
+                scenarios.append(build(market_context, economic_events))
+        if not scenarios:
+            scenarios.append(
+                {
+                    "name": "baseline",
+                    "description": "Default scenario awaiting implementation.",
+                    "inputs": {
+                        "market_context": market_context,
+                        "economic_events": economic_events,
+                    },
+                }
+            )
+        return scenarios
+
+    def generate_briefing_report(
+        self,
+        market_context: Dict[str, Any],
+        economic_events: List[Dict[str, Any]],
+        scenarios: List[Dict[str, Any]],
+    ) -> str:
+        """Generate a textual briefing report from the prepared artefacts."""
+        lines = ["=== Morning Briefing Report ===", ""]
+        lines.append("-- Market Context --")
+        if market_context:
+            for source, payload in market_context.items():
+                lines.append(f"Source: {source}")
+                lines.append(f"  Data: {payload}")
+        else:
+            lines.append("No market context available.")
+
+        lines.append("")
+        lines.append("-- Economic Events --")
+        if economic_events:
+            for event in economic_events:
+                lines.append(f"  - {event}")
+        else:
+            lines.append("No economic events retrieved.")
+
+        lines.append("")
+        lines.append("-- Trading Scenarios --")
+        if scenarios:
+            for scenario in scenarios:
+                name = scenario.get("name", "unnamed")
+                description = scenario.get("description", "")
+                lines.append(f"  * {name}: {description}")
+        else:
+            lines.append("No scenarios generated.")
+
+        lines.append("")
+        lines.append("=== End of Report ===")
+        return "\n".join(lines)
+
+    def run(self) -> str:
+        """Execute the full morning preparation workflow."""
+        market_context = self.collect_market_context()
+        economic_events = self.fetch_economic_events()
+        scenarios = self.build_trading_scenarios(market_context, economic_events)
+        return self.generate_briefing_report(market_context, economic_events, scenarios)
+
+
+def create_default_service(config_dir: str = "configs") -> MorningPreparationService:
+    """Factory that builds a service wired to the stub connectors."""
+    alpha_config = load_json_config(f"{config_dir}/alpha_vantage.json")
+    twelve_config = load_json_config(f"{config_dir}/twelve_data.json")
+    yfinance_config = load_json_config(f"{config_dir}/yfinance.json")
+    calendar_config = load_json_config(f"{config_dir}/economic_calendar.json")
+
+    connectors = [
+        AlphaVantageConnector.from_config(alpha_config),
+        TwelveDataConnector.from_config(twelve_config),
+        YFinanceConnector.from_config(yfinance_config),
+    ]
+    economic_calendar = EconomicCalendarClient(
+        provider=calendar_config.get("provider", "mock"),
+        metadata=calendar_config.get("metadata", {}),
+    )
+    return MorningPreparationService(
+        market_connectors=connectors,
+        economic_calendar=economic_calendar,
+    )

--- a/src/assistant/scheduler/__init__.py
+++ b/src/assistant/scheduler/__init__.py
@@ -1,0 +1,5 @@
+"""Scheduling utilities for assistant workflows."""
+
+from .tasks import SESSION_SCHEDULE, run_morning_preparation, scheduler_app
+
+__all__ = ["SESSION_SCHEDULE", "run_morning_preparation", "scheduler_app"]

--- a/src/assistant/scheduler/tasks.py
+++ b/src/assistant/scheduler/tasks.py
@@ -1,0 +1,83 @@
+"""Scheduling stubs for triggering morning preparation workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+try:  # pragma: no cover - optional dependency for illustrative scheduling
+    from celery import Celery
+    from celery.schedules import crontab
+except ImportError:  # pragma: no cover - executed when Celery is not available
+    Celery = None  # type: ignore
+    crontab = None  # type: ignore
+
+from ..morning import create_default_service
+
+TIMEZONE = "CET"
+
+
+@dataclass(frozen=True)
+class SessionTiming:
+    """Representation of a scheduled session."""
+
+    hour: int
+    minute: int
+    label: str
+
+
+SESSION_SCHEDULE: Dict[str, SessionTiming] = {
+    "pre_open": SessionTiming(hour=7, minute=30, label="07:30"),
+    "market_open": SessionTiming(hour=9, minute=0, label="09:00"),
+    "mid_morning": SessionTiming(hour=11, minute=0, label="11:00"),
+    "us_open": SessionTiming(hour=14, minute=30, label="14:30"),
+    "late_session": SessionTiming(hour=17, minute=0, label="17:00"),
+    "close_review": SessionTiming(hour=20, minute=0, label="20:00"),
+}
+
+
+scheduler_app: Optional[Celery]
+if Celery is not None:
+    scheduler_app = Celery("assistant_scheduler")
+    scheduler_app.conf.timezone = TIMEZONE
+else:  # pragma: no cover - scheduler stub without Celery available
+    scheduler_app = None
+
+
+def _celery_task(*decorator_args, **decorator_kwargs):  # pragma: no cover - helper
+    """Create a Celery task decorator that becomes a no-op when Celery is missing."""
+
+    def decorator(func):
+        if scheduler_app is not None:
+            return scheduler_app.task(*decorator_args, **decorator_kwargs)(func)
+        return func
+
+    return decorator
+
+
+@_celery_task(name="assistant.run_morning_preparation")
+def run_morning_preparation(session_label: str = SESSION_SCHEDULE["pre_open"].label) -> str:
+    """Trigger the morning preparation workflow for the requested session."""
+    if session_label == SESSION_SCHEDULE["pre_open"].label:
+        service = create_default_service()
+        return service.run()
+    return f"Session hook executed for {session_label}."
+
+
+def register_periodic_tasks(app: Optional[Celery] = None) -> None:
+    """Register periodic tasks for the defined sessions on the scheduler app."""
+    app = app or scheduler_app
+    if app is None or crontab is None:  # pragma: no cover - occurs without Celery
+        return
+    for name, timing in SESSION_SCHEDULE.items():
+        app.add_periodic_task(
+            crontab(minute=timing.minute, hour=timing.hour, timezone=TIMEZONE),
+            run_morning_preparation.s(timing.label),
+            name=f"assistant.{name}",
+        )
+
+
+if scheduler_app is not None:  # pragma: no cover - only executed with Celery
+    @scheduler_app.on_after_configure.connect
+    def _setup_periodic_tasks(sender, **_kwargs):
+        register_periodic_tasks(sender)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,15 @@
+"""Test package for assistant modules."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+SRC_DIR = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+# Preload the assistant package so absolute imports resolve during test discovery.
+if "assistant" not in sys.modules:
+    sys.modules["assistant"] = importlib.import_module("assistant")

--- a/tests/assistant/__init__.py
+++ b/tests/assistant/__init__.py
@@ -1,0 +1,9 @@
+"""Assistant test suite."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+if "assistant" not in sys.modules:
+    sys.modules["assistant"] = importlib.import_module("assistant")

--- a/tests/assistant/morning/__init__.py
+++ b/tests/assistant/morning/__init__.py
@@ -1,0 +1,1 @@
+"""Morning workflow tests."""

--- a/tests/assistant/morning/test_service.py
+++ b/tests/assistant/morning/test_service.py
@@ -1,0 +1,54 @@
+"""Unit tests for the MorningPreparationService orchestration."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import unittest
+from unittest.mock import MagicMock
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+SRC_DIR = ROOT_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+from assistant.morning import MorningPreparationService
+
+
+class MorningPreparationServiceTestCase(unittest.TestCase):
+    """Validate the orchestration logic of the morning service."""
+
+    def test_collect_market_context_aggregates_connector_payloads(self) -> None:
+        connector = MagicMock()
+        connector.fetch_latest_snapshot.return_value = {"price": 123}
+        connector.name = "alpha"
+        service = MorningPreparationService(market_connectors=[connector])
+
+        context = service.collect_market_context()
+
+        connector.fetch_latest_snapshot.assert_called_once()
+        self.assertIn("alpha", context)
+        self.assertEqual(context["alpha"], {"price": 123})
+
+    def test_run_invokes_pipeline_steps(self) -> None:
+        service = MorningPreparationService()
+        service.collect_market_context = MagicMock(return_value={"market": "data"})
+        service.fetch_economic_events = MagicMock(return_value=[{"event": "test"}])
+        service.build_trading_scenarios = MagicMock(return_value=[{"name": "baseline"}])
+        service.generate_briefing_report = MagicMock(return_value="report")
+
+        result = service.run()
+
+        service.collect_market_context.assert_called_once_with()
+        service.fetch_economic_events.assert_called_once_with()
+        service.build_trading_scenarios.assert_called_once_with({"market": "data"}, [{"event": "test"}])
+        service.generate_briefing_report.assert_called_once_with(
+            {"market": "data"},
+            [{"event": "test"}],
+            [{"name": "baseline"}],
+        )
+        self.assertEqual(result, "report")
+
+
+if __name__ == "__main__":  # pragma: no cover - test runner entry point
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement a stubbed MorningPreparationService that orchestrates market data collection, event retrieval, scenario building, and briefing generation
- add connector placeholders, scheduler tasks, configuration files, and a CLI to run the morning briefing
- document the new module layout and provide unit tests covering service orchestration

## Testing
- python -m unittest discover -s tests -t .


------
https://chatgpt.com/codex/tasks/task_e_68ce5461fcb48325be54f1c0db82a677